### PR TITLE
Protect against libraries that extend Array.prototype

### DIFF
--- a/diffview.js
+++ b/diffview.js
@@ -188,10 +188,10 @@ diffview = {
 		node2.setAttribute("href", "http://github.com/cemerick/jsdifflib");
 		
 		tdata.push(node = document.createElement("tbody"));
-		for (var idx in rows) node.appendChild(rows[idx]);
+		for (var idx in rows) rows.hasOwnProperty(idx) && node.appendChild(rows[idx]);
 		
 		node = celt("table", "diff" + (inline ? " inlinediff" : ""));
-		for (var idx in tdata) node.appendChild(tdata[idx]);
+		for (var idx in tdata) tdata.hasOwnProperty(idx) && node.appendChild(tdata[idx]);
 		return node;
 	}
 }


### PR DESCRIPTION
for (var ... in ...) loops should always check if the property being iterated isn't borrowed from somewhere else.
In this particular case, the code breaks if used in the same environment as old versions of PrototypeJS.
