### PR TITLE
Make the difflib code ES5 strict mode-compliant

### DIFF
--- a/difflib.js
+++ b/difflib.js
@@ -171,6 +171,7 @@ var difflib = {
 			var bestj = blo;
 			var bestsize = 0;
 			var j = null;
+			var k;
 	
 			var j2len = {};
 			var nothing = [];
@@ -249,7 +250,8 @@ var difflib = {
 			
 			matching_blocks.sort(difflib.__ntuplecomp);
 	
-			var i1 = j1 = k1 = block = 0;
+			var i1 = 0, j1 = 0, k1 = 0, block = 0;
+			var i2, j2, k2;
 			var non_adjacent = [];
 			for (var idx in matching_blocks) {
 				if (matching_blocks.hasOwnProperty(idx)) {

--- a/difflib.js
+++ b/difflib.js
@@ -28,9 +28,9 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
 DAMAGE.
 ***/
 /* Author: Chas Emerick <cemerick@snowtide.com> */
-__whitespace = {" ":true, "\t":true, "\n":true, "\f":true, "\r":true};
+var __whitespace = {" ":true, "\t":true, "\n":true, "\f":true, "\r":true};
 
-difflib = {
+var difflib = {
 	defaultJunkFunction: function (c) {
 		return __whitespace.hasOwnProperty(c);
 	},


### PR DESCRIPTION
According to http://es5.github.io/#C, "When a simple assignment occurs within strict mode code, its LeftHandSide must not evaluate to an unresolvable Reference. If it does a ReferenceError exception is thrown (8.7.2)". Also, `var` in the global scope defines properties on the global object (http://es5.github.io/#x10.4.1.1).
