### PR TITLE
Let diff's line number not be selected

### DIFF
--- a/diffview.css
+++ b/diffview.css
@@ -44,7 +44,11 @@ table.diff tbody th {
 	color:#886;
 	padding:.3em .5em .1em 2em;
 	text-align:right;
-	vertical-align:top
+	vertical-align:top;
+	-webkit-user-select:none;
+	-moz-user-select:none;
+	-ms-user-select:none;
+	user-select:none;
 }
 table.diff thead {
 	border-bottom:1px solid #BBC;


### PR DESCRIPTION
In the course of my use, I found that the line number is selected when the text is elected, which does not seem to be very friendly to use, and it is recommended that the line number be set to not be selected, or that configurable items be provided at initialization.